### PR TITLE
Reasignado usuario para notificaciones de depentabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
   schedule:
     interval: weekly
   assignees:
-  - ernestoalejo
+  - luiighi2693


### PR DESCRIPTION
Reasignado usuario para notificaciones de depentabot

Asigne mi usuario github para poder recibir dichas notificaciones